### PR TITLE
Fix Kafka targets in Prometheus config

### DIFF
--- a/config/prometheus.yml
+++ b/config/prometheus.yml
@@ -4,7 +4,7 @@ global:
 scrape_configs:
   - job_name: 'kafka'
     static_configs:
-      - targets: ['kafka-1:9102', 'kafka-2:9102']
+      - targets: ['kafka:9102']
   
   - job_name: 'flink'
     static_configs:


### PR DESCRIPTION
## Summary
- update kafka targets to use single instance `kafka:9102`

## Testing
- `docker compose config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6863ac29684083269ee9a513211a419f